### PR TITLE
cli: use a signed type for return value

### DIFF
--- a/src/tools/pipewire-cli.c
+++ b/src/tools/pipewire-cli.c
@@ -1028,7 +1028,7 @@ static void do_input(void *data, int fd, enum spa_io mask)
 {
 	struct data *d = data;
 	char buf[4096], *error;
-	size_t r;
+	ssize_t r;
 
 	if (mask & SPA_IO_IN) {
 		while (true) {


### PR DESCRIPTION
read() returns ssize_t where a negative number is used for errors.
The value was read into a size_t and then checked for <0.

Change to ssize_t to handle the negative number.