### PR TITLE
meson.build: remove automagic docs and manpages

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -157,16 +157,16 @@ subdir('spa')
 subdir('src')
 subdir('pkgconfig')
 
-doxygen = find_program('doxygen', required: false)
-if doxygen.found()
-  subdir('doc')
-else
-  message('Documentation disabled without doxygen')
+if get_option('enable_docs')
+  doxygen_dep = find_program('doxygen')
+  if doxygen_dep.found()
+    subdir('doc')
+  endif
 endif
 
-xmltoman = find_program('xmltoman', required: false)
-if xmltoman.found()
-  subdir('man')
-else
-  message('Man page disabled without xmltoman')
+if get_option('enable_man')
+  xmltoman_dep = find_program('xmltoman')
+  if xmltoman_dep.found()
+    subdir('man')
+  endif
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,8 @@
+option('enable_docs',
+       description: 'Build documentation',
+       type: 'boolean',
+       value: false)
+option('enable_man',
+       description: 'Build manpages',
+       type: 'boolean',
+       value: false)


### PR DESCRIPTION
As mentioned in #18 it's annoying to have automagic dependencies, e.g. if one uses a source based distro, where it's desirable to enable such things via flags and not have these determined automagically, depending on what is installed on the host