### PR TITLE
v4l2: check device caps

### DIFF
--- a/spa/plugins/v4l2/v4l2-utils.c
+++ b/spa/plugins/v4l2/v4l2-utils.c
@@ -83,7 +83,9 @@ static int spa_v4l2_open(struct impl *this)
 		return -err;
 	}
 
-	if ((port->cap.capabilities & V4L2_CAP_VIDEO_CAPTURE) == 0) {
+	if ((port->cap.capabilities & V4L2_CAP_VIDEO_CAPTURE) == 0 ||
+	    ((port->cap.capabilities & V4L2_CAP_DEVICE_CAPS) &&
+	     (port->cap.device_caps & V4L2_CAP_VIDEO_CAPTURE) == 0)) {
 		spa_log_error(port->log, "v4l2: %s is no video capture device", props->device);
 		return -ENODEV;
 	}


### PR DESCRIPTION
Recent kernels add metadata devices next to UVC capture devices. These have the V4L2_CAP_DEVICE_CAPS and V4L2_CAP_VIDEO_CAPTURE flags set in capabilities, but V4L2_CAP_VIDEO_CAPTURE unset in device_caps.
Check device caps as well to determine video capture capability. Fixes #37.