### PR TITLE
__STDC_VERSION__ may be undefined

### DIFF
--- a/spa/include/spa/support/log.h
+++ b/spa/include/spa/support/log.h
@@ -98,7 +98,8 @@ struct spa_log {
 
 #define spa_log_level_enabled(l,lev) ((l) && (l)->level >= (lev))
 
-#if __STDC_VERSION__ >= 199901L
+#if defined(__USE_ISOC11) || defined(__USE_ISOC99) || \
+    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)
 
 #define spa_log_log(l,lev,...)					\
 	if (SPA_UNLIKELY (spa_log_level_enabled (l, lev)))	\

--- a/src/pipewire/log.h
+++ b/src/pipewire/log.h
@@ -61,7 +61,8 @@ pw_log_logv(enum spa_log_level level,
 /** Check if a loglevel is enabled \memberof pw_log */
 #define pw_log_level_enabled(lev) (pw_log_level >= (lev))
 
-#if __STDC_VERSION__ >= 199901L
+#if defined(__USE_ISOC11) || defined(__USE_ISOC99) || \
+    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)
 
 #define pw_log_logc(lev,...)				\
 	if (SPA_UNLIKELY(pw_log_level_enabled (lev)))	\


### PR DESCRIPTION
Clang++ (and g++) don't define __STDC_VERSION__ which results in

 include/spa/support/log.h:101:5: error: '__STDC_VERSION__' is not defined, evaluates to 0 [-Werror,-Wundef]
 #if __STDC_VERSION__ >= 199901L
 include/pipewire/log.h:64:5: error: '__STDC_VERSION__' is not defined, evaluates to 0 [-Werror,-Wundef]
 #if __STDC_VERSION__ >= 199901L

so check if __STDC_VERSION__ is defined before comparing.
Also, include/feature.h additionally defines __USE_ISOC99 (and
__USE_ISOC11 for C11 extension), so check these as well.