### PR TITLE
v4l2: fix enumerating frame interval for continuous/step-wise devices

### DIFF
--- a/spa/plugins/v4l2/v4l2-utils.c
+++ b/spa/plugins/v4l2/v4l2-utils.c
@@ -782,6 +782,9 @@ spa_v4l2_enum_format(struct impl *this,
 							 port->frmival.stepwise.step.denominator,
 							 port->frmival.stepwise.step.numerator);
 			}
+
+			port->frmsize.index++;
+			port->next_frmsize = true;
 			break;
 		}
 		n_fractions++;


### PR DESCRIPTION
A device that supports continuous/step-wise frame interval will
report the correct frame intervals for index 0 and EINVAL for
every other index.
(https://linuxtv.org/downloads/v4l-dvb-apis/uapi/v4l/vidioc-enum-frameintervals.html)

Previously, the code would exit from the loop after successfully
reading index 0, without marking that the iteration of frame
interval completed. Therefore, the next time the function was
called the same frame intervals would be read, instead of advancing
to the next frame size or format type.
Instead, mark that we need to try and read the next format size.

Fixes #56