### PR TITLE
Install header needed to compile pipewire-jack

### DIFF
--- a/src/pipewire/meson.build
+++ b/src/pipewire/meson.build
@@ -19,6 +19,7 @@ pipewire_headers = [
   'factory.h',
   'pipewire.h',
   'port.h',
+  'private.h',
   'properties.h',
   'protocol.h',
   'proxy.h',


### PR DESCRIPTION
I'm trying to compile pipewire-jack as a standalone module instead of getting it into the full pipewire source and recompile everything. This header is needed to be installed in order for the include preprocessor checks to pass. This is the only change needed on this side apparently, everything else needs to be done in the pipewire-jack side.