### PR TITLE
Bump apiversion and soversion for PW 0.2.x

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,8 +17,8 @@ else
   pipewire_version_nano = 0
 endif
 
-apiversion = '0.1'
-soversion = 0
+apiversion = '0.2'
+soversion = 1
 libversion = '@0@.@1@.0'.format(soversion, pipewire_version_minor.to_int() * 100 + pipewire_version_micro.to_int())
 
 prefix = get_option('prefix')


### PR DESCRIPTION
PipeWire 0.2.0 is not API and ABI compatible with previous versions and we should let people know about that.