### PR TITLE
Revert "Drop api version suffix from library name"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ pipewire_libdir = join_paths(prefix, get_option('libdir'))
 pipewire_localedir = join_paths(prefix, get_option('localedir'))
 pipewire_sysconfdir = join_paths(prefix, get_option('sysconfdir'))
 
-modules_install_dir = join_paths(get_option('libdir'), 'pipewire')
+modules_install_dir = join_paths(get_option('libdir'), 'pipewire-@0@'.format(apiversion))
 
 gnome = import('gnome')
 
@@ -54,7 +54,7 @@ cdata.set('PACKAGE_STRING', '"PipeWire @0@"'.format(pipewire_version))
 cdata.set('PACKAGE_TARNAME', '"pipewire"')
 cdata.set('PACKAGE_URL', '"http://pipewire.org"')
 cdata.set('PACKAGE_VERSION', '"@0@"'.format(pipewire_version))
-cdata.set('MODULEDIR', '"@0@/pipewire"'.format(pipewire_libdir))
+cdata.set('MODULEDIR', '"@0@/pipewire-@1@"'.format(pipewire_libdir,apiversion))
 cdata.set('PIPEWIRE_CONFIG_DIR', '"@0@/pipewire"'.format(pipewire_sysconfdir))
 cdata.set('VERSION', '"@0@"'.format(pipewire_version))
 cdata.set('PLUGINDIR', '"@0@/spa"'.format(pipewire_libdir))

--- a/pkgconfig/libpipewire.pc.in
+++ b/pkgconfig/libpipewire.pc.in
@@ -7,5 +7,5 @@ moduledir=@moduledir@
 Name: libpipewire
 Description: PipeWire Interface
 Version: @VERSION@
-Libs: -L${libdir} -lpipewire
+Libs: -L${libdir} -lpipewire-@PIPEWIRE_API_VERSION@
 Cflags: -I${includedir} -D_REENTRANT

--- a/pkgconfig/meson.build
+++ b/pkgconfig/meson.build
@@ -17,7 +17,7 @@ pkg_files = [
 
 foreach p : pkg_files
   infile = p + '.pc.in'
-  outfile = p + '.pc'
+  outfile = p + '-0.1.pc'
   configure_file(input : infile,
     output : outfile,
     configuration : pkgconf,

--- a/src/modules/spa/meson.build
+++ b/src/modules/spa/meson.build
@@ -9,7 +9,7 @@ pipewire_module_spa_monitor = shared_library('pipewire-module-spa-monitor',
   include_directories : [configinc, spa_inc],
   link_with : spalib,
   install : true,
-  install_dir : '@0@/pipewire'.format(get_option('libdir')),
+  install_dir : '@0@/pipewire-0.1'.format(get_option('libdir')),
   dependencies : [mathlib, dl_lib, pipewire_dep],
 )
 
@@ -19,7 +19,7 @@ pipewire_module_spa_node = shared_library('pipewire-module-spa-node',
   include_directories : [configinc, spa_inc],
   link_with : spalib,
   install : true,
-  install_dir : '@0@/pipewire'.format(get_option('libdir')),
+  install_dir : '@0@/pipewire-0.1'.format(get_option('libdir')),
   dependencies : [mathlib, dl_lib, pipewire_dep],
 )
 
@@ -29,6 +29,6 @@ pipewire_module_spa_node_factory = shared_library('pipewire-module-spa-node-fact
   include_directories : [configinc, spa_inc],
   link_with : spalib,
   install : true,
-  install_dir : '@0@/pipewire'.format(get_option('libdir')),
+  install_dir : '@0@/pipewire-0.1'.format(get_option('libdir')),
   dependencies : [mathlib, dl_lib, pipewire_dep],
 )

--- a/src/pipewire/meson.build
+++ b/src/pipewire/meson.build
@@ -74,7 +74,7 @@ libpipewire_c_args = [
   '-D_POSIX_C_SOURCE',
 ]
 
-libpipewire = shared_library('pipewire', pipewire_sources,
+libpipewire = shared_library('pipewire-@0@'.format(apiversion), pipewire_sources,
   version : libversion,
   soversion : soversion,
   c_args : libpipewire_c_args,


### PR DESCRIPTION
Reverts PipeWire/pipewire#78

We want to have 0.2 in the library name so that we can see the difference between old
and new api (we ignore the intermediate 0.2.0 and 0.2.1 versions)