### PR TITLE
meson: Add an uninstalled target and script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -183,3 +183,6 @@ if get_option('man')
     warning('Man page generation was enabled, but xmltoman is not available')
   endif
 endif
+
+setenv = find_program('pw-uninstalled.sh')
+run_target('uninstalled', command : [setenv, '-b@0@'.format(meson.build_root())])

--- a/pw-uninstalled.sh
+++ b/pw-uninstalled.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+while getopts ":b:" opt; do
+	case ${opt} in
+		b)
+			BUILDDIR=${OPTARG}
+			;;
+		\?)
+			echo "Invalid option: -${OPTARG}"
+			exit -1
+			;;
+		:)
+			echo "Option -${OPTARG} requires an argument"
+			exit -1
+			;;
+	esac
+done
+
+if [ -z "${BUILDDIR}" ]; then
+	BUILDDIR=${PWD}/build
+	echo "Using default build directory: ${BUILDDIR}"
+fi
+
+if [ ! -d ${BUILDDIR} ]; then
+	echo "Invalid build directory: ${BUILDDIR}"
+	exit -1
+fi
+
+export PIPEWIRE_CONFIG_FILE="${BUILDDIR}/src/daemon/pipewire.conf"
+export SPA_PLUGIN_DIR="${BUILDDIR}/spa/plugins"
+export PIPEWIRE_MODULE_DIR="${BUILDDIR}/src/modules"
+export PATH="${BUILDDIR}/src/daemon:${PATH}"
+
+# FIXME: find a nice, shell-neutral way to specify a prompt
+${SHELL}


### PR DESCRIPTION
This makes it easier to run PipeWire from the build environment