### PR TITLE
Fix build when systemd is found but not libsystemd

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -128,7 +128,7 @@ endif
 if get_option('systemd')
   systemd = dependency('systemd', required: false)
   systemd_dep = dependency('libsystemd', required: false)
-  if systemd.found()
+  if systemd.found() and systemd_dep.found()
     cdata.set('HAVE_SYSTEMD_DAEMON', 1)
   else
     warning('Systemd integration was enabled, but systemd is not available')


### PR DESCRIPTION
Getting the following otherwise:

```
[13/28] Compiling C object 'src/modules/src@modules@@pipewire-module-protocol-native@sha/module-protocol-native.c.o'.
FAILED: src/modules/src@modules@@pipewire-module-protocol-native@sha/module-protocol-native.c.o
ccache cc -Isrc/modules/src@modules@@pipewire-module-protocol-native@sha -Isrc/modules -I../src/modules -I. -I../ -Ispa/include -I../spa/include -Isrc -I../src -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu99 -O2 -g -fPIC -pthread -DHAVE_CONFIG_H -D_GNU_SOURCE  -MD -MQ 'src/modules/src@modules@@pipewire-module-protocol-native@sha/module-protocol-native.c.o' -MF 'src/modules/src@modules@@pipewire-module-protocol-native@sha/module-protocol-native.c.o.d' -o 'src/modules/src@modules@@pipewire-module-protocol-native@sha/module-protocol-native.c.o' -c ../src/modules/module-protocol-native.c
../src/modules/module-protocol-native.c:36:10: fatal error: systemd/sd-daemon.h: No such file or directory
 #include <systemd/sd-daemon.h>
          ^~~~~~~~~~~~~~~~~~~~~
```