### PR TITLE
meson: Fix configure when systemd option is set to false

### DIFF
--- a/src/daemon/meson.build
+++ b/src/daemon/meson.build
@@ -29,6 +29,6 @@ executable('pipewire',
   dependencies : [pipewire_dep],
 )
 
-if systemd.found()
+if get_option('systemd') and systemd.found()
   subdir('systemd')
 endif


### PR DESCRIPTION
Configuring version.h using configuration

src/modules/meson.build:74:0: ERROR:  Unknown variable "systemd_dep".

[Full log](http://ix.io/1ubD)