### PR TITLE
module-rtkit: define RLIMIT_RTTIME in case it isn't defined.

### DIFF
--- a/src/modules/module-rtkit.c
+++ b/src/modules/module-rtkit.c
@@ -95,6 +95,10 @@ struct impl {
 #define RTKIT_SERVICE_NAME "org.freedesktop.RealtimeKit1"
 #define RTKIT_OBJECT_PATH "/org/freedesktop/RealtimeKit1"
 
+#ifndef RLIMIT_RTTIME
+#define RLIMIT_RTTIME 15
+#endif
+
 /** \cond */
 struct pw_rtkit_bus {
 	DBusConnection *bus;


### PR DESCRIPTION
musl libc doesn't define RLIMIT_RTTIME so lets define it in case it isn't defined.

one of the steps required for #48 