### PR TITLE
Quote "$@" in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -19,5 +19,5 @@
 
 rm -rf ./build
 mkdir build
-meson build $@
+meson build "$@"
 ln -s build/Makefile Makefile


### PR DESCRIPTION
An unquoted $@ will break for arguments with spaces in their names. Unquoted $@ will work until it doesn't, and then it can be tricky to track down exactly what went wrong. Using "$@" will save someone some headache in the future.