### PR TITLE
add .editorconfig files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 8
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Use 2 spaces for meson files
+[*.build]
+indent_style = space
+indent_size = 2

--- a/src/gst/.editorconfig
+++ b/src/gst/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
These files help editors choose the correct coding style
conventions, mostly useful for the indentation style

Pipewire uses tab characters of size 8 in all of its codebase
except in the meson files and in the gstreamer plugins,
which use 2-space indentation