### PR TITLE
meson: find dependencies only when necessary + some other dependency-related fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -170,8 +170,11 @@ rt_lib = cc.find_library('rt', required : false) # clock_gettime
 dl_lib = cc.find_library('dl', required : false)
 pthread_lib = dependency('threads')
 dbus_dep = dependency('dbus-1')
+sdl_dep = dependency('sdl2', required : false)
 
-glib_dep = dependency('glib-2.0', version : '>=2.32.0', required : false)
+if get_option('gstreamer') or get_option('pipewire-pulseaudio')
+  glib_dep = dependency('glib-2.0', version : '>=2.32.0')
+endif
 
 if get_option('gstreamer')
   gobject_dep = dependency('gobject-2.0')
@@ -201,6 +204,7 @@ if get_option('pipewire-pulseaudio')
 endif
 
 if get_option('pipewire-alsa')
+  alsa_dep = dependency('alsa')
   subdir('pipewire-alsa/alsa-plugins')
 endif
 

--- a/spa/meson.build
+++ b/spa/meson.build
@@ -1,20 +1,5 @@
 #project('spa', 'c')
 
-alsa_dep = dependency('alsa')
-v4l2_dep = dependency('libv4l2')
-x11_dep = dependency('x11', required : false)
-sdl_dep = dependency('sdl2', required : false)
-libva_dep = dependency('libva', required : false)
-sbc_dep = dependency('sbc', required : false)
-avcodec_dep = dependency('libavcodec', required : false)
-avformat_dep = dependency('libavformat', required : false)
-avfilter_dep = dependency('libavfilter', required : false)
-libudev_dep = dependency('libudev')
-threads_dep = dependency('threads')
-speexdsp_dep = dependency('speexdsp')
-sdl_dep = dependency('sdl2', required : false)
-bluez_dep = dependency('bluez', version : '>= 4.101', required : false)
-
 #cc = meson.get_compiler('c')
 #dl_lib = cc.find_library('dl', required : false)
 #pthread_lib = dependencies('threads')
@@ -25,6 +10,30 @@ spa_inc = include_directories('include')
 subdir('include')
 
 if get_option('spa-plugins')
+  # common dependencies
+  if get_option('alsa') or get_option('v4l2')
+    libudev_dep = dependency('libudev')
+  endif
+
+  # plugin-specific dependencies
+  if get_option('alsa')
+    alsa_dep = dependency('alsa')
+  endif
+  if get_option('audioconvert')
+    speexdsp_dep = dependency('speexdsp')
+  endif
+  if get_option('bluez5')
+    bluez_dep = dependency('bluez', version : '>= 4.101')
+    sbc_dep = dependency('sbc')
+  endif
+  if get_option('ffmpeg')
+    avcodec_dep = dependency('libavcodec')
+    avformat_dep = dependency('libavformat')
+  endif
+  if get_option('v4l2')
+    v4l2_dep = dependency('libv4l2')
+  endif
+
   subdir('plugins')
 endif
 

--- a/spa/plugins/meson.build
+++ b/spa/plugins/meson.build
@@ -10,10 +10,10 @@ endif
 if get_option('audiotestsrc')
   subdir('audiotestsrc')
 endif
-if get_option('bluez5') and sbc_dep.found() and bluez_dep.found()
+if get_option('bluez5')
   subdir('bluez5')
 endif
-if get_option('ffmpeg') and avcodec_dep.found()
+if get_option('ffmpeg')
   subdir('ffmpeg')
 endif
 if get_option('support')

--- a/spa/plugins/support/meson.build
+++ b/spa/plugins/support/meson.build
@@ -7,7 +7,7 @@ spa_support_lib = shared_library('spa-support',
 			spa_support_sources,
 			c_args : [ '-D_GNU_SOURCE' ],
 			include_directories : [ spa_inc],
-			dependencies : threads_dep,
+			dependencies : pthread_lib,
 			install : true,
 			install_dir : '@0@/spa/support'.format(get_option('libdir')))
 

--- a/spa/plugins/test/meson.build
+++ b/spa/plugins/test/meson.build
@@ -3,6 +3,6 @@ test_sources = ['fakesrc.c', 'fakesink.c', 'plugin.c']
 testlib = shared_library('spa-test',
                           test_sources,
                           include_directories : [ spa_inc],
-                          dependencies : threads_dep,
+                          dependencies : pthread_lib,
                           install : true,
                           install_dir : '@0@/spa/test'.format(get_option('libdir')))

--- a/spa/plugins/videotestsrc/meson.build
+++ b/spa/plugins/videotestsrc/meson.build
@@ -3,6 +3,6 @@ videotestsrc_sources = ['videotestsrc.c', 'plugin.c']
 videotestsrclib = shared_library('spa-videotestsrc',
                                  videotestsrc_sources,
                                  include_directories : [ spa_inc],
-                                 dependencies : threads_dep,
+                                 dependencies : pthread_lib,
                                  install : true,
                                  install_dir : '@0@/spa/videotestsrc'.format(get_option('libdir')))


### PR DESCRIPTION
This allows finding dependencies conditionally, only when the enabled features actually need them.

Examples of scenarios that are being fixed:
* compile with -Dv4l2=false -> libv4l2 doesn't need to be installed in the system
* compile with -Dbluez5=true -> bluez and sbc MUST be installed in the system
* compile with -Dspa-plugins=false and -Dpipewire-alsa=true -> alsa must be installed and found
* compile with -Dpipewire-pulseaudio=false and -Dgstreamer=false -> glib doesn't need to be installed

This also removes some dependencies that were being found but not used, like X11, libva and avfilter