### PR TITLE
meson: prefix the names of the tests so that they are unique in the tree

### DIFF
--- a/spa/tests/meson.build
+++ b/spa/tests/meson.build
@@ -5,8 +5,8 @@ test_apps = [
 ]
 
 foreach a : test_apps
-  test(a,
-	executable(a, a + '.c',
+  test('spa-' + a,
+	executable('spa-' + a, a + '.c',
 		dependencies : [dl_lib, pthread_lib, mathlib ],
 		include_directories : [spa_inc ],
 		c_args : [ '-D_GNU_SOURCE' ],
@@ -17,11 +17,11 @@ foreach a : test_apps
 endforeach
 
 if have_cpp
-test_cpp = executable('test-cpp', 'test-cpp.cpp',
+test_cpp = executable('spa-test-cpp', 'test-cpp.cpp',
                         include_directories : [spa_inc ],
                         dependencies : [],
                         install : false)
-test('test-cpp', test_cpp)
+test('spa-test-cpp', test_cpp)
 endif
 
 benchmark_apps = [
@@ -30,8 +30,8 @@ benchmark_apps = [
 ]
 
 foreach a : benchmark_apps
-  benchmark(a,
-	executable(a, a + '.c',
+  benchmark('spa-' + a,
+	executable('spa-' + a, a + '.c',
 		dependencies : [dl_lib, pthread_lib, mathlib ],
 		include_directories : [spa_inc ],
 		c_args : [ '-D_GNU_SOURCE' ],

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -10,8 +10,8 @@ test_apps = [
 ]
 
 foreach a : test_apps
-  test(a,
-	executable(a, a + '.c',
+  test('pw-' + a,
+	executable('pw-' + a, a + '.c',
 		dependencies : [pipewire_dep],
 		c_args : [ '-D_GNU_SOURCE' ],
 		install : false),
@@ -23,8 +23,8 @@ endforeach
 
 
 if have_cpp
-test_cpp = executable('test-cpp', 'test-cpp.cpp',
+test_cpp = executable('pw-test-cpp', 'test-cpp.cpp',
                         dependencies : [pipewire_dep],
                         install : false)
-test('test-cpp', test_cpp)
+test('pw-test-cpp', test_cpp)
 endif


### PR DESCRIPTION
meson < 0.46 does not allow two targets to share the same name;
meson >= 0.46 relaxes that requirement, but I see no reason to require
a new version of meson just for this