### PR TITLE
daemon: getopt returns int, declare it as such to avoid comparison issues

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
 		{"name",	1, NULL, 'n'},
 		{NULL,		0, NULL, 0}
 	};
-	char c;
+	int c;
 
 	pw_init(&argc, &argv);
 


### PR DESCRIPTION
On some toolchains/architectures, a char with -1 value is not equal
to the integer -1, resulting in this code to think that it got
an unrecognized command line option