### PR TITLE
v4l2: do not keep non-capture devices open

### DIFF
--- a/spa/plugins/v4l2/v4l2-utils.c
+++ b/spa/plugins/v4l2/v4l2-utils.c
@@ -80,6 +80,8 @@ static int spa_v4l2_open(struct impl *this)
 	if (xioctl(port->fd, VIDIOC_QUERYCAP, &port->cap) < 0) {
 		err = errno;
 		spa_log_error(port->log, "QUERYCAP: %m");
+		close(port->fd);
+		port->fd = -1;
 		return -err;
 	}
 
@@ -87,6 +89,8 @@ static int spa_v4l2_open(struct impl *this)
 	    ((port->cap.capabilities & V4L2_CAP_DEVICE_CAPS) &&
 	     (port->cap.device_caps & V4L2_CAP_VIDEO_CAPTURE) == 0)) {
 		spa_log_error(port->log, "v4l2: %s is no video capture device", props->device);
+		close(port->fd);
+		port->fd = -1;
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
If VIDIOC_QUERYCAP fails, or V4L2_CAP_VIDEO_CAPTURE is not set,
spa_v4l2_open should close the port file descriptor again.