### PR TITLE
spa: install pod/vararg.h

### DIFF
--- a/spa/include/spa/meson.build
+++ b/spa/include/spa/meson.build
@@ -75,6 +75,7 @@ spa_pod_headers = [
   'pod/iter.h',
   'pod/parser.h',
   'pod/pod.h',
+  'pod/vararg.h',
 ]
 install_headers(spa_pod_headers,
   subdir : 'spa/pod')


### PR DESCRIPTION
This header is missing from installations and a simple #include <pipewire/pipewire.h> fails