### PR TITLE
daemon: use correct type for getopt_long() return value

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 		{"name",	1, NULL, 'n'},
 		{NULL,		0, NULL, 0}
 	};
-	char c;
+	int c;
 
 	pw_init(&argc, &argv);
 


### PR DESCRIPTION
Depending on the compiler configuration 'char' may be an unsigned type
which will not work as expected.

Signed-off-by: Matthias Fend <matthias.fend@wolfvision.net>