### PR TITLE
gstpipewiresrc: clear timestamps when processing a buffer

### DIFF
--- a/src/gst/gstpipewiresrc.c
+++ b/src/gst/gstpipewiresrc.c
@@ -409,6 +409,9 @@ on_process (void *_data)
 
   GST_LOG_OBJECT (pwsrc, "got new buffer %p", buf);
 
+  GST_BUFFER_PTS (buf) = GST_CLOCK_TIME_NONE;
+  GST_BUFFER_DTS (buf) = GST_CLOCK_TIME_NONE;
+
   h = data->header;
   if (h) {
     GST_INFO ("pts %" G_GUINT64_FORMAT ", dts_offset %"G_GUINT64_FORMAT, h->pts, h->dts_offset);


### PR DESCRIPTION
This is necessary for 'do-timestamp' to work if the source provides no
timestamps. Without this, the timestamp from the first use will remain,
because the basesrc only overwrites timestamps that are
GST_CLOCK_TIME_NONE.