### PR TITLE
travis: fix runing autogen.sh after changes to detect meson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 script:
   - >
     docker run -it --rm -v $PWD:/workdir gkiagia/pipewire_build_environment:latest bash -c
-    'cd /workdir && ./autogen.sh \
+    'cd /workdir && env MESON=meson ./autogen.sh \
       -Ddocs=true \
       -Daudiomixer=true \
       -Daudiotestsrc=true \


### PR DESCRIPTION
On the CI docker image, there is no "which" command,
so meson cannot be detected.