### PR TITLE
travis: run make install and check for headers that have not been installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,8 @@ script:
       -Dtest=true \
       -Dvideotestsrc=true \
       -Dvolume=true \
-    && make && make test'
+    && make \
+    && make test \
+    && env DESTDIR=i make install \
+    && env PREFIX=build/i/usr/local ./check_missing_headers.sh \
+    '

--- a/check_missing_headers.sh
+++ b/check_missing_headers.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# This script will tell you if there are headers in the source tree
+# that have not been installed in $PREFIX
+
+LIST=""
+
+for i in `find spa/include -name '*.h' | sed s#spa/include/##`;
+do
+	[ -f $PREFIX/include/$i ] || LIST="$i $LIST"
+done
+
+for i in `find src/extensions -name '*.h' | sed s#src/#pipewire/#`;
+do
+	[ -f $PREFIX/include/$i ] || LIST="$i $LIST"
+done
+
+for i in `find src/pipewire -name '*.h' -a -not -name '*private.h' | sed s#src/##`;
+do
+	[ -f $PREFIX/include/$i ] || LIST="$i $LIST"
+done
+
+for i in $LIST;
+do
+	echo "$i not installed"
+done
+
+if [ "$LIST" != "" ];
+then
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This will prevent in the future the situation where we add a new header but we forget to list it in meson.build