### PR TITLE
deviceprovider: fix probing without starting

### DIFF
--- a/src/gst/gstpipewiredeviceprovider.c
+++ b/src/gst/gstpipewiredeviceprovider.c
@@ -265,7 +265,7 @@ static void do_add_node(void *data)
   nd->dev = new_node (self, nd);
   if (nd->dev) {
     if(self->list_only)
-      *self->devices = g_list_prepend (*self->devices, gst_object_ref_sink (nd->dev));
+      self->devices = g_list_prepend (self->devices, gst_object_ref_sink (nd->dev));
     else
       gst_device_provider_device_add (GST_DEVICE_PROVIDER (self), nd->dev);
   }
@@ -555,6 +555,8 @@ gst_pipewire_device_provider_probe (GstDeviceProvider * provider)
 
   t = pw_core_get_type(c);
 
+  self->type = pw_core_get_type (c);
+
   if (!(r = pw_remote_new (c, NULL, sizeof(*data))))
     goto failed;
 
@@ -612,7 +614,9 @@ gst_pipewire_device_provider_probe (GstDeviceProvider * provider)
   pw_core_destroy (c);
   pw_loop_destroy (l);
 
-  return *self->devices;
+  self->type = NULL;
+
+  return self->devices;
 
 failed:
   pw_loop_destroy (l);

--- a/src/gst/gstpipewiredeviceprovider.h
+++ b/src/gst/gstpipewiredeviceprovider.h
@@ -98,7 +98,7 @@ struct _GstPipeWireDeviceProvider {
 
   gboolean end;
   gboolean list_only;
-  GList **devices;
+  GList *devices;
 };
 
 struct _GstPipeWireDeviceProviderClass {


### PR DESCRIPTION
self->type is needed in registry_event_global() so it must be set in
gst_pipewire_device_provider_probe() as well.

self->devices is initialized as NULL when probing is started. So it should
be just a simple GList* pointer.

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>