### PR TITLE
link: only reuse buffers if the port is at least in paused state

### DIFF
--- a/src/pipewire/link.c
+++ b/src/pipewire/link.c
@@ -559,7 +559,7 @@ static int do_allocation(struct pw_link *this, uint32_t in_state, uint32_t out_s
 		spa_debug_port_info(2, oinfo);
 		spa_debug_port_info(2, iinfo);
 	}
-	if (output->allocation.n_buffers) {
+	if (output->allocation.n_buffers && out_state > PW_PORT_STATE_READY) {
 		out_flags = 0;
 		in_flags = SPA_PORT_INFO_FLAG_CAN_USE_BUFFERS;
 
@@ -567,7 +567,8 @@ static int do_allocation(struct pw_link *this, uint32_t in_state, uint32_t out_s
 
 		pw_log_debug("link %p: reusing %d output buffers %p", this,
 				allocation.n_buffers, allocation.buffers);
-	} else if (input->allocation.n_buffers && input->mix == NULL) {
+	} else if (input->allocation.n_buffers && input->mix == NULL &&
+		   in_state > PW_PORT_STATE_READY) {
 		out_flags = SPA_PORT_INFO_FLAG_CAN_USE_BUFFERS;
 		in_flags = 0;
 


### PR DESCRIPTION
If existing buffers of a port are reused during allocation then this port
is not changed in any way. If it is still in the 'ready' state then will
remains there and the link activation never finishes.
This can happen if a previous link setup was aborted during allocation.

Fix this by only reusing buffer if the port is at least paused.


I'm not sure if this is the correct solution, but I don't know of any other way force the port to make the state transition.