### PR TITLE
builder: fix calls to builder_add that are not terminated by NULL

### DIFF
--- a/spa/include/spa/pod/builder.h
+++ b/spa/include/spa/pod/builder.h
@@ -574,7 +574,8 @@ spa_pod_builder_addv(struct spa_pod_builder *builder,
 	return spa_pod_builder_deref(builder, builder->frame[builder->state.depth].ref);
 }
 
-static inline void *spa_pod_builder_add(struct spa_pod_builder *builder, const char *format, ...)
+static inline __attribute__((__sentinel__)) void *
+spa_pod_builder_add(struct spa_pod_builder *builder, const char *format, ...)
 {
 	void *res;
 	va_list args;

--- a/spa/plugins/alsa/alsa-monitor.c
+++ b/spa/plugins/alsa/alsa-monitor.c
@@ -173,22 +173,22 @@ fill_item(struct impl *this, snd_ctl_card_info_t *card_info, snd_pcm_info_t *dev
 	if (!(str && *str))
 		str = udev_device_get_syspath(dev);
 	if (str && *str) {
-		spa_pod_builder_add(builder, "s", "device.bus_path", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.bus_path", "s", str, NULL);
 	}
 	if ((str = udev_device_get_syspath(dev)) && *str) {
-		spa_pod_builder_add(builder, "s", "sysfs.path", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "sysfs.path", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(dev, "ID_ID")) && *str) {
-		spa_pod_builder_add(builder, "s", "udev.id", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "udev.id", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(dev, "ID_BUS")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.bus", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.bus", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(dev, "SUBSYSTEM")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.subsystem", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.subsystem", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(dev, "ID_VENDOR_ID")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.vendor.id", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.vendor.id", "s", str, NULL);
 	}
 	str = udev_device_get_property_value(dev, "ID_VENDOR_FROM_DATABASE");
 	if (!(str && *str)) {
@@ -198,18 +198,18 @@ fill_item(struct impl *this, snd_ctl_card_info_t *card_info, snd_pcm_info_t *dev
 		}
 	}
 	if (str && *str) {
-		spa_pod_builder_add(builder, "s", "device.vendor.name", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.vendor.name", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(dev, "ID_MODEL_ID")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.product.id", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.product.id", "s", str, NULL);
 	}
-	spa_pod_builder_add(builder, "s", "device.product.name", "s", name, 0);
+	spa_pod_builder_add(builder, "s", "device.product.name", "s", name, NULL);
 
 	if ((str = udev_device_get_property_value(dev, "ID_SERIAL")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.serial", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.serial", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(dev, "SOUND_FORM_FACTOR")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.form_factor", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.form_factor", "s", str, NULL);
 	}
 	*item = spa_pod_builder_add(builder, "]>", NULL);
 

--- a/spa/plugins/alsa/alsa-utils.c
+++ b/spa/plugins/alsa/alsa-utils.c
@@ -143,7 +143,7 @@ spa_alsa_enum_format(struct state *state, uint32_t *index,
 	spa_pod_builder_push_object(&b, state->type.param.idEnumFormat, state->type.format);
 	spa_pod_builder_add(&b,
 			"I", state->type.media_type.audio,
-			"I", state->type.media_subtype.raw, 0);
+			"I", state->type.media_subtype.raw, NULL);
 
 	snd_pcm_format_mask_alloca(&fmask);
 	snd_pcm_hw_params_get_format_mask(params, fmask);

--- a/spa/plugins/v4l2/v4l2-monitor.c
+++ b/spa/plugins/v4l2/v4l2-monitor.c
@@ -132,22 +132,22 @@ static void fill_item(struct impl *this, struct item *item, struct udev_device *
 	if (!(str && *str))
 		str = udev_device_get_syspath(item->udevice);
 	if (str && *str) {
-		spa_pod_builder_add(builder, "s", "device.bus_path", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.bus_path", "s", str, NULL);
 	}
 	if ((str = udev_device_get_syspath(item->udevice)) && *str) {
-		spa_pod_builder_add(builder, "s", "sysfs.path", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "sysfs.path", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(item->udevice, "ID_ID")) && *str) {
-		spa_pod_builder_add(builder, "s", "udev.id", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "udev.id", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(item->udevice, "ID_BUS")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.bus", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.bus", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(item->udevice, "SUBSYSTEM")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.subsystem", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.subsystem", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(item->udevice, "ID_VENDOR_ID")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.vendor.id", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.vendor.id", "s", str, NULL);
 	}
 	str = udev_device_get_property_value(item->udevice, "ID_VENDOR_FROM_DATABASE");
 	if (!(str && *str)) {
@@ -157,17 +157,17 @@ static void fill_item(struct impl *this, struct item *item, struct udev_device *
 		}
 	}
 	if (str && *str) {
-		spa_pod_builder_add(builder, "s", "device.vendor.name", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.vendor.name", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(item->udevice, "ID_MODEL_ID")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.product.id", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.product.id", "s", str, NULL);
 	}
-	spa_pod_builder_add(builder, "s", "device.product.name", "s", name, 0);
+	spa_pod_builder_add(builder, "s", "device.product.name", "s", name, NULL);
 	if ((str = udev_device_get_property_value(item->udevice, "ID_SERIAL")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.serial", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.serial", "s", str, NULL);
 	}
 	if ((str = udev_device_get_property_value(item->udevice, "ID_V4L_CAPABILITIES")) && *str) {
-		spa_pod_builder_add(builder, "s", "device.capabilities", "s", str, 0);
+		spa_pod_builder_add(builder, "s", "device.capabilities", "s", str, NULL);
 	}
 
 	*result = spa_pod_builder_add(builder, "]>", NULL);

--- a/spa/plugins/v4l2/v4l2-source.c
+++ b/spa/plugins/v4l2/v4l2-source.c
@@ -458,22 +458,22 @@ static int port_get_format(struct spa_node *node,
 
 	spa_pod_builder_add(builder,
 		"I", port->current_format.media_type,
-		"I", port->current_format.media_subtype, 0);
+		"I", port->current_format.media_subtype, NULL);
 
 	if (port->current_format.media_subtype == t->media_subtype.raw) {
 		spa_pod_builder_add(builder,
 			":", t->format_video.format,    "I", port->current_format.info.raw.format,
 			":", t->format_video.size,      "R", &port->current_format.info.raw.size,
-			":", t->format_video.framerate, "F", &port->current_format.info.raw.framerate, 0);
+			":", t->format_video.framerate, "F", &port->current_format.info.raw.framerate, NULL);
 	} else if (port->current_format.media_subtype == t->media_subtype_video.mjpg ||
 		   port->current_format.media_subtype == t->media_subtype_video.jpeg) {
 		spa_pod_builder_add(builder,
 			":", t->format_video.size,      "R", &port->current_format.info.mjpg.size,
-			":", t->format_video.framerate, "F", &port->current_format.info.mjpg.framerate, 0);
+			":", t->format_video.framerate, "F", &port->current_format.info.mjpg.framerate, NULL);
 	} else if (port->current_format.media_subtype == t->media_subtype_video.h264) {
 		spa_pod_builder_add(builder,
 			":", t->format_video.size,      "R", &port->current_format.info.h264.size,
-			":", t->format_video.framerate, "F", &port->current_format.info.h264.framerate, 0);
+			":", t->format_video.framerate, "F", &port->current_format.info.h264.framerate, NULL);
 	} else
 		return -EIO;
 

--- a/spa/plugins/v4l2/v4l2-utils.c
+++ b/spa/plugins/v4l2/v4l2-utils.c
@@ -692,15 +692,15 @@ spa_v4l2_enum_format(struct impl *this,
 	spa_pod_builder_push_object(builder, t->param.idEnumFormat, t->format);
 	spa_pod_builder_add(builder,
 			"I", media_type,
-			"I", media_subtype, 0);
+			"I", media_subtype, NULL);
 
 	if (media_subtype == t->media_subtype.raw) {
 		spa_pod_builder_add(builder,
-			":", t->format_video.format, "I", video_format, 0);
+			":", t->format_video.format, "I", video_format, NULL);
 	}
 	spa_pod_builder_add(builder,
 		":", t->format_video.size, "R", &SPA_RECTANGLE(port->frmsize.discrete.width,
-							       port->frmsize.discrete.height), 0);
+							       port->frmsize.discrete.height), NULL);
 
 	prop = spa_pod_builder_deref(builder,
 			spa_pod_builder_push_prop(builder, t->format_video.framerate,


### PR DESCRIPTION
spa_pod_builder_add() is a va_args function that is terminated by a NULL
argument. The last argument must be a pointer type, because otherwise
checking for a NULL pointer can fail.

The __attribute__((__sentinel__)) prints a compiler warning, if the last
argument of a call to spa_pod_builder_add() is not a pointer type.

Fix all sentinel warnings by replacing all integer type 0 with pointer
type NULL in calls to spa_pod_builder_add().