### PR TITLE
alsa: make corrections on the timeout based on how fast ALSA consumes samples

### DIFF
--- a/spa/plugins/alsa/alsa-utils.c
+++ b/spa/plugins/alsa/alsa-utils.c
@@ -604,7 +604,21 @@ static int get_status(struct state *state, snd_pcm_uframes_t *delay)
 
 static int update_time(struct state *state, uint64_t nsec, snd_pcm_sframes_t delay, bool slave)
 {
-	double err, corr;
+	double err, corr, drift;
+	snd_pcm_sframes_t consumed;
+
+	consumed = state->fill_level - delay;
+	if (state->alsa_started && consumed > 0) {
+		double sysclk_diff = nsec - state->last_time;
+		double devclk_diff = ((double) consumed) * 1e9 / state->rate;
+		drift = sysclk_diff / devclk_diff;
+		drift = SPA_CLAMP(drift, 0.6, 1.0);
+
+		spa_log_trace_fp(state->log, "cons:%ld sclk:%f dclk:%f drift:%f",
+			consumed, sysclk_diff, devclk_diff, drift);
+	} else {
+		drift = 1.0;
+	}
 
 	if (state->rate_match) {
 		state->delay = state->rate_match->delay;
@@ -664,7 +678,7 @@ static int update_time(struct state *state, uint64_t nsec, snd_pcm_sframes_t del
 			corr, delay, err, state->threshold * corr,
 			state->threshold);
 
-	state->next_time += state->threshold / corr * 1e9 / state->rate;
+	state->next_time += state->threshold / corr * drift * 1e9 / state->rate;
 	state->last_threshold = state->threshold;
 
 	return 0;
@@ -795,6 +809,10 @@ again:
 		goto again;
 
 	state->sample_count += total_written;
+	state->fill_level += total_written;
+
+	clock_gettime(CLOCK_MONOTONIC, &state->now);
+	state->last_time = SPA_TIMESPEC_TO_NSEC (&state->now);
 
 	if (!state->alsa_started && total_written > 0) {
 		spa_log_trace(state->log, "snd_pcm_start %lu", written);
@@ -968,6 +986,8 @@ static int handle_play(struct state *state, uint64_t nsec, snd_pcm_uframes_t del
 	if ((res = update_time(state, nsec, delay, false)) < 0)
 		return res;
 
+	state->fill_level = delay;
+
 	if (spa_list_is_empty(&state->ready)) {
 		struct spa_io_buffers *io = state->io;
 
@@ -1106,6 +1126,7 @@ int spa_alsa_start(struct state *state)
 
 	state->threshold = (state->size * state->rate + state->rate_denom-1) / state->rate_denom;
 	state->last_threshold = state->threshold;
+	state->fill_level = 0;
 
 	init_loop(state);
 	state->safety = 0.0;

--- a/spa/plugins/alsa/alsa-utils.h
+++ b/spa/plugins/alsa/alsa-utils.h
@@ -141,7 +141,9 @@ struct state {
 	int64_t sample_time;
 	uint64_t next_time;
 	uint64_t base_time;
+	uint64_t last_time;
 
+	snd_pcm_uframes_t fill_level;
 	uint64_t underrun;
 	double safety;
 


### PR DESCRIPTION
This feels a bit hacky, but it actually makes huge difference when pipewire is running in qemu.

The idea is that it keeps track of how much samples are in the device (fill level) and calculates how many are consumed when a timeout occurs. Then it converts that into a time based on the sample rate and compares it to the system clock time that elapsed since the last write to the device. The division between the two gives a rate (drift) that can be used to shorten the timeout window.

So for instance, if the timeout window was 21.3 ms, but the device actually consumed an equivalent of 28 ms in samples, the drift will be 21.3/28 = 0.76 and the next timeout window will be approximately 21.3 * 0.76 = 16.1 ms

To avoid making things worse, the drift is clamped between 0.6 and 1.0. Min 0.6 was arbitrarily chosen, but sometimes alsa does report strange numbers, causing the drift to be very low, which in turn causes an early wakeup. Max 1.0 basically means that we don't care if the device is consuming samples slower. In that case, the early wakeup mechanism will throttle pipewire.

Fixes #163