### PR TITLE
Allow audio-dsp to be instantiated in "convert" mode

### DIFF
--- a/spa/plugins/audioconvert/audioconvert.c
+++ b/spa/plugins/audioconvert/audioconvert.c
@@ -80,6 +80,8 @@ struct impl {
 #define MODE_MERGE	1
 #define MODE_CONVERT	2
 	int mode;
+	bool fmt_is_set[2];
+	bool buffers_set[2];
 	bool started;
 
 	struct spa_handle *hnd_fmt[2];
@@ -780,11 +782,11 @@ impl_node_port_set_param(void *object,
 	if (id == SPA_PARAM_Format) {
 		if (param == NULL)
 			clean_convert(this);
-		else if ((direction == SPA_DIRECTION_OUTPUT && this->mode == MODE_MERGE) ||
-		    (direction == SPA_DIRECTION_INPUT && this->mode == MODE_SPLIT)) {
+		else if (this->fmt_is_set[SPA_DIRECTION_REVERSE(direction)]) {
 			if ((res = setup_convert(this)) < 0)
 				return res;
 		}
+		this->fmt_is_set[direction] = (param != NULL);
 	}
 	return res;
 }
@@ -811,11 +813,11 @@ impl_node_port_use_buffers(void *object,
 					direction, port_id, buffers, n_buffers)) < 0)
 		return res;
 
-	if ((direction == SPA_DIRECTION_OUTPUT && this->mode == MODE_MERGE) ||
-	    (direction == SPA_DIRECTION_INPUT && this->mode == MODE_SPLIT)) {
+	if (buffers && this->buffers_set[SPA_DIRECTION_REVERSE(direction)]) {
 		if ((res = setup_buffers(this, SPA_DIRECTION_INPUT)) < 0)
 			return res;
 	}
+	this->buffers_set[direction] = (buffers != NULL);
 	return res;
 }
 

--- a/src/modules/module-audio-dsp/audio-dsp.c
+++ b/src/modules/module-audio-dsp/audio-dsp.c
@@ -290,6 +290,8 @@ struct pw_node *pw_audio_dsp_new(struct pw_core *core,
 		goto error;
 	}
 
+	mode = pw_properties_get(props, "audio-dsp.mode");
+
 	snprintf(node_name, sizeof(node_name), "system_%s", alias);
 	for (i = 0; node_name[i]; i++) {
 		if (node_name[i] == ':' || node_name[i] == ',')
@@ -306,11 +308,13 @@ struct pw_node *pw_audio_dsp_new(struct pw_core *core,
 	if ((str = pw_properties_get(props, PW_KEY_NODE_ID)) != NULL)
 		pw_properties_set(props, PW_KEY_NODE_SESSION, str);
 
-	if (direction == PW_DIRECTION_OUTPUT) {
-		pw_properties_set(props, "merger.monitor", "1");
-		mode = "merge";
-	} else {
-		mode = "split";
+	if (!mode) {
+		if (direction == PW_DIRECTION_OUTPUT) {
+			pw_properties_set(props, "merger.monitor", "1");
+			mode = "merge";
+		} else {
+			mode = "split";
+		}
 	}
 
 	pw_properties_set(props, "factory.mode", mode);


### PR DESCRIPTION
These changes allow us to use the audio-dsp in a mode where it simply presents one input and one output port and just converts from one format to another.

The use case in AGL is to be able to have multiple DSPs on each session, each one handling a different stream. Streams are meant to be used to group the connected clients based on their "role" and allow having different volume/mute controls per each group, without sacrificing the master volume, of course, which should override all other controls.

The convert DSP in this case is used for two reasons:
1. to provide the "master" volume
2. to mix streams for final playback by alsa, since the input port of the alsa-sink node is not capable of mixing streams.

This is the pipeline diagram that we implement:
![image](https://user-images.githubusercontent.com/19818/61117469-3f48c600-a49f-11e9-8cfc-b1bea208a262.png)

