### PR TITLE
audioconvert/fmtconvert: assume F32 on the other port when listing formats

### DIFF
--- a/spa/plugins/audioconvert/fmtconvert.c
+++ b/spa/plugins/audioconvert/fmtconvert.c
@@ -336,7 +336,7 @@ static int port_enum_formats(void *object,
 			if (other->have_format)
 				info = other->format;
 			else
-				info.info.raw.format = SPA_AUDIO_FORMAT_S16;
+				info.info.raw.format = SPA_AUDIO_FORMAT_F32;
 
 			if (!other->have_format ||
 			    info.info.raw.format == SPA_AUDIO_FORMAT_F32P ||


### PR DESCRIPTION
This allows picking F32LE as the default format on links that have
no restriction and it avoids failing negotiation when the restricted
end cannot handle S16/F32/F32P

For instance this pipeline would previously fail:

```
  audio-dsp mode=merge ! audio-dsp mode=convert ! alsa-sink
old negotiation:     S16LE                   S24_32LE
new negotiation:     F32LE                   S24_32LE
```

The link between the audio-dsp nodes has no restriction, so previously
it would negotiate S16LE, which would then fail to negotiate with alsa-sink
because fmtconvert does not know how to convert S16LE to S24_32LE directly.

With this change, the middle link negotiates to F32LE, which can be
converted to anything.