### PR TITLE
travis: fix the build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,17 @@ before_install:
 script:
   - >
     docker run -it --rm -v $PWD:/workdir gkiagia/pipewire_build_environment:latest bash -c
-    'cd /workdir && env MESON=meson ./autogen.sh \
-      -Ddocs=true \
-      -Daudiomixer=true \
-      -Daudiotestsrc=true \
-      -Dffmpeg=true \
-      -Dtest=true \
-      -Dvideotestsrc=true \
-      -Dvolume=true \
-    && make \
-    && make test \
-    && env DESTDIR=i make install \
-    && env PREFIX=build/i/usr/local ./check_missing_headers.sh \
+    'cd /workdir \
+      && env MESON=meson ./autogen.sh \
+        -Ddocs=true \
+        -Daudiomixer=true \
+        -Daudiotestsrc=true \
+        -Dffmpeg=true \
+        -Dtest=true \
+        -Dvideotestsrc=true \
+        -Dvolume=true \
+      && make \
+      && make test \
+      && env DESTDIR=$PWD/build/i make install \
+      && env PREFIX=$PWD/build/i/usr/local ./check_missing_headers.sh \
     '


### PR DESCRIPTION
It turns out that indentation matters...
My apologies that it took so long to figure this out

PS: the build still fails, but this is because some optional spa plugins have not been updated to API changes. I have verified that it works when these plugins are disabled. IMHO, the CI should build all code in the repository and find these issues, so I have kept these plugins enabled.