### PR TITLE
meson.build: fix meson version warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('pipewire', ['c' ],
   version : '0.2.9',
   license : 'MIT',
-  meson_version : '>= 0.42.0',
+  meson_version : '>= 0.44.0',
   default_options : [ 'warning_level=1',
                       'c_std=gnu99',
                       'buildtype=debugoptimized' ])


### PR DESCRIPTION
Features are used from 0.44 but min version is specified as 0.42.
Bump min version to 0.44.

Signed-off-by: Matt Porter <mporter@konsulko.com>