### PR TITLE
Fix infinite loop in a2dp-sink

### DIFF
--- a/spa/plugins/bluez5/a2dp-sink.c
+++ b/spa/plugins/bluez5/a2dp-sink.c
@@ -559,6 +559,10 @@ static int flush_data(struct impl *this, uint64_t now_time)
 			n_bytes += add_data(this, src, l1);
 		if (n_bytes <= 0) {
 			port->need_data = true;
+			spa_list_remove(&b->link);
+			b->outstanding = true;
+			spa_node_call_reuse_buffer(&this->callbacks, 0, b->id);
+			port->ready_offset = 0;
 			break;
 		}
 


### PR DESCRIPTION
This PR fixes an infinite loop that always happens when playing audio with a2dp-sink.

Steps to reproduce:
- Run pipewire with the example media-session
- Connect a bluetooth speaker and wait for the a2dp-sink node to be created
- Try to play audio using the example audio-src executable
- No audio is played and the a2dp-sink gets into an infinite loop state

The audio plays without issues if we use this patch