### PR TITLE
bluez: set bluez profile property when emitting node

### DIFF
--- a/spa/include/spa/utils/keys.h
+++ b/spa/include/spa/utils/keys.h
@@ -76,6 +76,7 @@ extern "C" {
 #define SPA_KEY_API_BLUEZ5_PATH		"api.bluez5.path"		/**< a bluez5 path */
 #define SPA_KEY_API_BLUEZ5_DEVICE	"api.bluez5.device"		/**< an internal bluez5 device */
 #define SPA_KEY_API_BLUEZ5_TRANSPORT	"api.bluez5.transport"		/**< an internal bluez5 transport */
+#define SPA_KEY_API_BLUEZ5_PROFILE	"api.bluez5.profile"		/**< a bluetooth profile */
 #define SPA_KEY_API_BLUEZ5_ADDRESS	"api.bluez5.address"		/**< a bluetooth address */
 
 /** keys for jack api */

--- a/spa/plugins/bluez5/bluez5-device.c
+++ b/spa/plugins/bluez5/bluez5-device.c
@@ -74,11 +74,12 @@ struct impl {
 static void emit_node (struct impl *this, struct spa_bt_transport *t, const char *factory_name)
 {
         struct spa_device_object_info info;
-        struct spa_dict_item items[1];
+        struct spa_dict_item items[2];
         char transport[32];
 
         snprintf(transport, sizeof(transport), "pointer:%p", t);
         items[0] = SPA_DICT_ITEM_INIT(SPA_KEY_API_BLUEZ5_TRANSPORT, transport);
+        items[1] = SPA_DICT_ITEM_INIT(SPA_KEY_API_BLUEZ5_PROFILE, spa_bt_profile_name(t->profile));
 
         info = SPA_DEVICE_OBJECT_INFO_INIT();
         info.type = SPA_TYPE_INTERFACE_Node;

--- a/spa/plugins/bluez5/defs.h
+++ b/spa/plugins/bluez5/defs.h
@@ -138,6 +138,26 @@ static inline enum spa_bt_profile spa_bt_profile_from_uuid(const char *uuid)
 		return 0;
 }
 
+static inline const char *spa_bt_profile_name (enum spa_bt_profile profile) {
+      switch (profile) {
+      case SPA_BT_PROFILE_A2DP_SOURCE:
+        return "a2dp-source";
+      case SPA_BT_PROFILE_A2DP_SINK:
+        return "a2dp-sink";
+      case SPA_BT_PROFILE_HSP_HS:
+        return "hsp-hs";
+      case SPA_BT_PROFILE_HSP_AG:
+        return "hsp-ag";
+      case SPA_BT_PROFILE_HFP_HF:
+        return "hfp-hf";
+      case SPA_BT_PROFILE_HFP_AG:
+        return "hfp-ag";
+      default:
+        break;
+      }
+      return "unknown";
+}
+
 struct spa_bt_monitor;
 
 struct spa_bt_adapter {


### PR DESCRIPTION
We need to expose the bluetooth profile in the nodes so that external
applications know how to handle them.