### PR TITLE
meson: add examples option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,6 +2,10 @@ option('docs',
        description: 'Build documentation',
        type: 'boolean',
        value: false)
+option('examples',
+       description: 'Build examples',
+       type: 'boolean',
+       value: true)
 option('man',
        description: 'Build manpages',
        type: 'boolean',

--- a/spa/meson.build
+++ b/spa/meson.build
@@ -39,7 +39,9 @@ endif
 
 subdir('tools')
 subdir('tests')
-subdir('examples')
+if get_option('examples')
+  subdir('examples')
+endif
 
 pkgconfig.generate(filebase : 'libspa-@0@'.format(spaversion),
   name : 'libspa',

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,7 +4,9 @@ subdir('extensions')
 subdir('daemon')
 subdir('tools')
 subdir('modules')
-subdir('examples')
+if get_option('examples')
+  subdir('examples')
+endif
 subdir('tests')
 
 if get_option('gstreamer')


### PR DESCRIPTION
Add an option to allow the user to disable examples, this will allow to
build pipewire without alsa. Without this option, build with
-Dpipewire-alsa=false -Dalsa=false fails on:

src/examples/meson.build:47:0: ERROR: Unknown variable "alsa_dep".

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>