### PR TITLE
Fix version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('pipewire', ['c' ],
-  version : '0.2.9',
+  version : '0.2.90',
   license : 'MIT',
   meson_version : '>= 0.50.0',
   default_options : [ 'warning_level=1',


### PR DESCRIPTION
One cannot check for pre-released PW version as 0.2.9 is supposed to be a bugfix release of PW 0.2. This should maybe be set even to 0.2.92, but this is enough for me to use ifdefs to support both PW versions.