### PR TITLE
acp: Check return value of asprintf

### DIFF
--- a/spa/plugins/alsa/acp/acp.c
+++ b/spa/plugins/alsa/acp/acp.c
@@ -295,7 +295,7 @@ static int add_pro_profile(pa_card *impl, uint32_t index)
 	ap->input_name = pa_xstrdup("pro-input");
 	ap->priority = 1;
 
-	asprintf(&device, "hw:%d", index);
+	pa_assert_se(asprintf(&device, "hw:%d", index) >= 0);
 
 	if ((err = snd_ctl_open(&ctl_hndl, device, 0)) < 0) {
 		pa_log_error("can't open control for card %s: %s",
@@ -331,7 +331,7 @@ static int add_pro_profile(pa_card *impl, uint32_t index)
 				pa_log_error("error pcm info: %s", snd_strerror(err));
 		}
 		if (err >= 0) {
-			asprintf(&name, "Mapping pro-output-%d", dev);
+			pa_assert_se(asprintf(&name, "Mapping pro-output-%d", dev) >= 0);
 			m = pa_alsa_mapping_get(ps, name);
 			m->description = pa_xstrdup(desc);
 			m->device_strings = pa_split_spaces_strv(devstr);
@@ -361,7 +361,7 @@ static int add_pro_profile(pa_card *impl, uint32_t index)
 				pa_log_error("error pcm info: %s", snd_strerror(err));
 		}
 		if (err >= 0) {
-			asprintf(&name, "Mapping pro-input-%d", dev);
+			pa_assert_se(asprintf(&name, "Mapping pro-input-%d", dev) >= 0);
 			m = pa_alsa_mapping_get(ps, name);
 			m->description = pa_xstrdup(desc);
 			m->device_strings = pa_split_spaces_strv(devstr);


### PR DESCRIPTION
Building with `-D c_args="-D_FORTIFY_SOURCE=2"` triggers warnings:

    ../spa/plugins/alsa/acp/acp.c: In function ‘add_pro_profile’:
    ../spa/plugins/alsa/acp/acp.c:298:2: warning: ignoring return value of ‘asprintf’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
      298 |  asprintf(&device, "hw:%d", index);
          |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ../spa/plugins/alsa/acp/acp.c:334:4: warning: ignoring return value of ‘asprintf’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
      334 |    asprintf(&name, "Mapping pro-output-%d", dev);
          |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ../spa/plugins/alsa/acp/acp.c:364:4: warning: ignoring return value of ‘asprintf’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
      364 |    asprintf(&name, "Mapping pro-input-%d", dev);
          |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~