### PR TITLE
pipewire-jack: fix use of `pthread_cancel`

### DIFF
--- a/pipewire-jack/src/pipewire-jack.c
+++ b/pipewire-jack/src/pipewire-jack.c
@@ -2992,7 +2992,7 @@ jack_client_t * jack_client_open (const char *client_name,
 		client->server_name = NULL;
 
 	client->props = pw_properties_new(
-			"loop.cancel", "true",
+			"loop.cancel", "false",
 			PW_KEY_REMOTE_NAME, client->server_name,
 			PW_KEY_CLIENT_NAME, client_name,
 			PW_KEY_CLIENT_API, "jack",


### PR DESCRIPTION
`pthread_cancel` is always undefined behavior when used on arbitrary user code, and JACK clients are not written with it in mind. Thread cancellation should be opt-in rather than always-on, and so for the JACK shim it makes the most sense for the default mode to be joining the process thread (like in JACK and JACK2) and for hard-killing the thread to be a separate function that the library consumer must use explicitly - and only when they can prove that the cancelled thread is safe to hard-kill.