### PR TITLE
Include `bool` definition in `version.h.in`

### DIFF
--- a/src/pipewire/version.h.in
+++ b/src/pipewire/version.h.in
@@ -11,6 +11,8 @@
 extern "C" {
 #endif
 
+#include <stdbool.h> /* bool */
+
 /** Return the version of the header files. Keep in mind that this is
 a macro and not a function, so it is impossible to get the pointer of
 it. */


### PR DESCRIPTION
Include the definition of `bool` from `stdbool.h` in the `version.h.in` file.

Would fix the following unkown type name error:
https://github.com/pop-os/xdg-desktop-portal-cosmic/issues/6