### PR TITLE
Make bap qos set configurable

### DIFF
--- a/doc/dox/config/pipewire-props.7.md
+++ b/doc/dox/config/pipewire-props.7.md
@@ -917,6 +917,22 @@ PipeWire Opus Pro audio profile duplex max bitrate.
 PipeWire Opus Pro audio profile duplex frame duration (1/10 ms).
 
 @PAR@ monitor-prop  bluez5.bcast_source.config = []  # JSON
+
+@PAR@ monitor-prop  bluez5.bap.set_name = "48_2_1"  # string
+BAP QoS set name that can be configured to select specific BAP QoS combination
+
+@PAR@ monitor-prop  bluez5.bap.rtn = 5 # integer
+BAP QoS retransmission number that needs to be configured for the set_name
+
+@PAR@ monitor-prop  bluez5.bap.latency = 20 # integer
+BAP QoS latency that needs to be configured for the set_name
+
+@PAR@ monitor-prop  bluez5.bap.delay = 40000 # integer
+BAP QoS delay that needs to be configured for the set_name
+
+@PAR@ monitor-prop  bluez5.framing = false # boolean
+BAP framing mode that needs to be configured for the set_name
+
 \parblock
 Example:
 ```


### PR DESCRIPTION
This PR adds option to configure and select the QoS based on user defined parameters for BAP unicast transport. This allows provision to use specific set (For E.g: 48_2_1, 48_2_2 etc) to be used for CIS transmission allowing flexibility for the user to have control on SDU length and other QoS config that may have impact to cater specific use case suiting different application needs.