### PR TITLE
Fix spelling errors in comments and log messages

### DIFF
--- a/spa/plugins/bluez5/rate-control.h
+++ b/spa/plugins/bluez5/rate-control.h
@@ -128,7 +128,7 @@ static inline bool spa_bt_ptp_valid(struct spa_bt_ptp *p)
  * in 1/z expansion. This guarantees f(z) is causal, and G(z) = (z-1) q(z) / p(z).
  * We can choose p(z) and q(z) to improve low-pass properties of F(z).
  *
- * Simplest choice is p(z)=(z-1)^2 and q(z)=1, but that does not supress
+ * Simplest choice is p(z)=(z-1)^2 and q(z)=1, but that does not suppress
  * high frequency response in F(z). Better choice is p(z) = (z-u)*(z-v)*(z-w)
  * and q(z) = z - r. Causality requires r = u + v + w - 2.
  * Then,

--- a/src/modules/module-avb/es-builder.c
+++ b/src/modules/module-avb/es-builder.c
@@ -50,7 +50,7 @@ static void *es_builder_desc_entity_milan_v12(struct server *server,
         &entity_state);
 
     if (!ptr_alloc) {
-        pw_log_error("Error durring allocation\n");
+        pw_log_error("Error during allocation\n");
         spa_assert(0);
     }
 

--- a/src/pipewire/impl-port.c
+++ b/src/pipewire/impl-port.c
@@ -782,7 +782,7 @@ static int process_capability_param(void *data, int seq,
 	if (spa_param_dict_compare(old, param) == 0)
 		return 0;
 
-	pw_log_debug("port %p: got %s capabilty %p", this,
+	pw_log_debug("port %p: got %s capability %p", this,
 			pw_direction_as_string(this->direction), param);
 	if (param)
 		pw_log_pod(SPA_LOG_LEVEL_DEBUG, param);


### PR DESCRIPTION
-Fix durring → during in es-builder.c error message 
-Fix capabilty → capability in impl-port.c debug log 
-Fix supress → suppress in rate-control.h comment

Improve code readability