### PR TITLE
Fix segfault in load_spa_handle

### DIFF
--- a/src/pipewire/pipewire.c
+++ b/src/pipewire/pipewire.c
@@ -232,7 +232,7 @@ static struct spa_handle *load_spa_handle(const char *lib,
 	if (lib == NULL)
 		lib = sup->support_lib;
 
-	while ((p = strstr(lib, "../")) != NULL)
+	while (lib != NULL && (p = strstr(lib, "../")) != NULL)
 		lib = p + 3;
 
 	pw_log_debug("load lib:'%s' factory-name:'%s'", lib, factory_name);


### PR DESCRIPTION
We hit this segfault while testing rodio's PipeWire backend.
Related issue: https://github.com/RustAudio/cpal/issues/1158
I'm not sure if other `while ((p = strstr(lib, "../")) != NULL)` needs to be fixed.
@wtay