### PR TITLE
Stop ports of hidden type in jack from creating churn in pipewire graph recomputation

### DIFF
--- a/pipewire-jack/src/pipewire-jack.c
+++ b/pipewire-jack/src/pipewire-jack.c
@@ -930,6 +930,39 @@ static struct object *find_link(struct client *c, uint32_t src, uint32_t dst)
 	return NULL;
 }
 
+static inline bool port_is_jack_graph_relevant(struct client *c, struct object *o)
+{
+	if (o == NULL || o->type != INTERFACE_Port || o->removed)
+		return false;
+	if (!client_port_visible(c, o))
+		return false;
+	if (TYPE_ID_IS_HIDDEN(o->port.type_id))
+		return false;
+	return true;
+}
+
+static bool link_is_jack_graph_relevant(struct client *c,
+		struct object *src_port,
+		struct object *dst_port)
+{
+	return port_is_jack_graph_relevant(c, src_port) &&
+		port_is_jack_graph_relevant(c, dst_port) &&
+		TYPE_ID_IS_COMPATIBLE(src_port->port.type_id, dst_port->port.type_id);
+}
+
+static bool link_object_is_jack_graph_relevant(struct client *c, struct object *link)
+{
+	struct object *src_port, *dst_port;
+
+	if (link == NULL || link->type != INTERFACE_Link || link->removed)
+		return false;
+
+	src_port = find_type(c, link->port_link.src, INTERFACE_Port, true);
+	dst_port = find_type(c, link->port_link.dst, INTERFACE_Port, true);
+
+	return link_is_jack_graph_relevant(c, src_port, dst_port);
+}
+
 #if defined (__SSE__)
 #include <xmmintrin.h>
 static void mix_sse(float *dst, float *src[], uint32_t n_src, bool aligned, uint32_t n_samples)
@@ -3663,7 +3696,8 @@ static void node_info(void *data, const struct pw_node_info *info)
 					    (l->port_link.src_serial != p->serial &&
 					     l->port_link.dst_serial != p->serial))
 						continue;
-					queue_notify(c, NOTIFY_TYPE_CONNECT, l, 0, NULL);
+					if (link_object_is_jack_graph_relevant(c, l))
+						queue_notify(c, NOTIFY_TYPE_CONNECT, l, 0, NULL);
 				}
 				queue_notify(c, NOTIFY_TYPE_PORTREGISTRATION, p, 0, NULL);
 			}
@@ -4011,7 +4045,7 @@ static void registry_event_global(void *data, uint32_t id,
 				o->port.name, type_id);
 	}
 	else if (spa_streq(type, PW_TYPE_INTERFACE_Link)) {
-		struct object *p;
+		struct object *p, *src_port, *dst_port;
 
 		o = alloc_object(c, INTERFACE_Link);
 		if (o == NULL)
@@ -4027,6 +4061,7 @@ static void registry_event_global(void *data, uint32_t id,
 
 		if ((p = find_type(c, o->port_link.src, INTERFACE_Port, true)) == NULL)
 			goto exit_free;
+		src_port = p;
 		o->port_link.src_serial = p->serial;
 
 		o->port_link.src_ours = p->port.port != NULL &&
@@ -4040,6 +4075,7 @@ static void registry_event_global(void *data, uint32_t id,
 
 		if ((p = find_type(c, o->port_link.dst, INTERFACE_Port, true)) == NULL)
 			goto exit_free;
+		dst_port = p;
 		o->port_link.dst_serial = p->serial;
 
 		o->port_link.dst_ours = p->port.port != NULL &&
@@ -4060,6 +4096,7 @@ static void registry_event_global(void *data, uint32_t id,
 		pw_log_debug("%p: add link %d %u/%u->%u/%u", c, id,
 				o->port_link.src, o->port_link.src_serial,
 				o->port_link.dst, o->port_link.dst_serial);
+		do_emit = link_is_jack_graph_relevant(c, src_port, dst_port);
 	}
 	else if (spa_streq(type, PW_TYPE_INTERFACE_Metadata)) {
 		struct pw_proxy *proxy;
@@ -4182,7 +4219,10 @@ static void registry_event_global_remove(void *data, uint32_t id)
 			pw_log_info("%p: link %u %u/%u -> %u/%u removed", c, o->id,
 					o->port_link.src, o->port_link.src_serial,
 					o->port_link.dst, o->port_link.dst_serial);
-			queue_notify(c, NOTIFY_TYPE_CONNECT, o, 0, NULL);
+			if (link_object_is_jack_graph_relevant(c, o))
+				queue_notify(c, NOTIFY_TYPE_CONNECT, o, 0, NULL);
+			else
+				free_object(c, o);
 		} else {
 			pw_log_warn("unlink between unknown ports %d and %d",
 					o->port_link.src, o->port_link.dst);


### PR DESCRIPTION
I have created this PR due to an issue with Ardour DAW on KDE plasma. There are serious playback interruptions and sound crackling when cursor is moved on the taskbar icons in KDE during ardour playback.

Issue on ardour: https://tracker.ardour.org/view.php?id=9447

I have looked at this issue on pipewire: https://gitlab.freedesktop.org/pipewire/pipewire/-/work_items/3512
It does not fix the issue as I have tested in pipewire 1.6.2 and dev build from master.

On ardour side I have done some digging and expanded on this PR: https://github.com/Ardour/ardour/pull/1091
With this PR and some more changes, Ardour now ignores the callbacks for jack port events of type 'other'. Even with that, the issue is not resolved, which leads to this PR.
With these changes along with the changes on Ardour made in the PR mentioned above, this particular issue is resolved.

Although, I believe this PR does does not solve the heart of the problem, which is that when new ports connect/disconnect, there is a lot of churn happening causing interruptions on existing connected ports in pipewire jack. Here we are only filtering out the "other" port type from causing that churn.